### PR TITLE
Move logging args to script_main.

### DIFF
--- a/cs/eyrie/config.py
+++ b/cs/eyrie/config.py
@@ -235,7 +235,8 @@ def script_main(script_class, cache_region, **script_kwargs):
 
     parser.add_argument('-l', '--log-handler',
                         help=("Specify which log handler to use. "
-                              "These are defined in eyrie_api.ini."))
+                              "These are defined in the config file for each "
+                              "script."))
 
     blt = 'Logs a stack trace if the IOLoop is blocked for more than s seconds'
     parser.add_argument('--blocking-log-threshold',

--- a/cs/eyrie/config.py
+++ b/cs/eyrie/config.py
@@ -233,6 +233,10 @@ def script_main(script_class, cache_region, **script_kwargs):
                         help='Set the running process title',
                         default=script_kwargs.get('title', script_class.title))
 
+    parser.add_argument('-l', '--log-handler',
+                        help=("Specify which log handler to use. "
+                              "These are defined in eyrie_api.ini."))
+
     blt = 'Logs a stack trace if the IOLoop is blocked for more than s seconds'
     parser.add_argument('--blocking-log-threshold',
                         help=blt, default=blt_default, type=int, metavar='s')

--- a/cs/eyrie/vassal.py
+++ b/cs/eyrie/vassal.py
@@ -57,13 +57,7 @@ class Vassal(object):
     }
     title = '(eyrie:vassal)'
     app_name = 'eyrie'
-    args = [
-        (
-            ('-l', '--log-handler'),
-            {"help": ("Specify which log handler to use. "
-                      "These are defined in eyrie_api.ini.")}
-        )
-    ]
+    args = None
     cursor_factory = DictCursor
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
This is more in-line with the convention of `config.script_main` being the location for default command line args.