### PR TITLE
Add a couple escape hatches to logging config.

### DIFF
--- a/cs/eyrie/config.py
+++ b/cs/eyrie/config.py
@@ -219,7 +219,7 @@ def info_signal_handler(signal, frame):
                  ''.join(traceback.format_stack(frame)))
 
 
-def script_main(script_class, cache_region, **script_kwargs):
+def script_main(script_class, cache_region, _setup_logging=True, **script_kwargs):
     loop = script_kwargs.pop('loop', None)
     start_loop = script_kwargs.pop('start_loop', True)
     blt_default = script_kwargs.pop('blocking_log_threshold', 5)
@@ -271,7 +271,8 @@ def script_main(script_class, cache_region, **script_kwargs):
     if cache_region is not None:
         configure_caching(cache_region, pargs.config)
 
-    setup_logging(pargs.config, **kwargs)
+    if _setup_logging:
+        setup_logging(pargs.config, **kwargs)
     vassal = script_class(**kwargs)
 
     def hup_signal_handler(signal, frame):

--- a/cs/eyrie/vassal.py
+++ b/cs/eyrie/vassal.py
@@ -70,8 +70,8 @@ class Vassal(object):
         # command line to override this default.
         logger_name = '.'.join([self.__class__.__module__,
                                 self.__class__.__name__])
-        log_handler = kwargs.get('log-handler') or logger_name
-        self.logger = logging.getLogger(log_handler)
+        log_handler = kwargs.get('log_handler') or logger_name
+        self.logger = self.get_logger(log_handler)
 
         self.context = kwargs.get('context', zmq.Context())
         loop = kwargs.pop('loop', None)
@@ -88,6 +88,12 @@ class Vassal(object):
 
         if kwargs.get('init_db', False):
             self.init_db()
+
+    def get_logger(self, logger_name=None):
+        if logger_name is None:
+            logger_name = '.'.join([self.__class__.__module__,
+                                    self.__class__.__name__])
+        return logging.getLogger(logger_name)
 
     def set_ioloop(self, loop=None):
         if loop is None:


### PR DESCRIPTION
First, the business of getting a logger instance has been relegated to a `Vassal.get_logger` instance method. This way, subclasses can simply override that method to implement custom behavior. Second, `script_main` now accepts a `_setup_logging` boolean. If it's true (the default), the `setup_logging` function is invoked as normal. Otherwise, it's not called. This is to support situations where we are using something other than a file-based logging config.