### PR TITLE
Sample mode

### DIFF
--- a/cs/eyrie/scripts/kafka_consumer.py
+++ b/cs/eyrie/scripts/kafka_consumer.py
@@ -50,12 +50,13 @@ class Ranger(object):
         setup_logging(self.config_uri)
         app_settings = get_appsettings(self.config_uri, name=app_name)
         self.config = Configurator(settings=app_settings)
-        self.curr_proc.authkey = self.config.registry.settings['eyrie.authkey']
+        settings = self.config.registry.settings
+        self.curr_proc.authkey = settings['eyrie.authkey']
+
 
         self.msg_count = 0
         self.logger = logging.getLogger('rf.kafka')
 
-        settings = self.config.registry.settings
         self.commit_interval = int(settings.get('kafka.commit_interval',
                                                 self.commit_interval))
         self.commit_greenlet = None

--- a/cs/eyrie/scripts/kafka_consumer.py
+++ b/cs/eyrie/scripts/kafka_consumer.py
@@ -67,7 +67,7 @@ class Ranger(object):
 
         zk_hosts = settings.get('kafka.zk_hosts', zk_hosts)
         if zk_hosts is None:
-            raise ConfigurationError('No ZooKepper hosts provided')
+            raise ConfigurationError('No ZooKeeper hosts provided')
         group = settings.get('kafka.group', group)
         if group is None:
             raise ConfigurationError('No consumer group provided to join')

--- a/cs/eyrie/scripts/kafka_consumer.py
+++ b/cs/eyrie/scripts/kafka_consumer.py
@@ -23,8 +23,7 @@ from pyramid.config import aslist
 
 import zmq.green as zmq
 
-from cs.eyrie.config import setup_logging
-from cs.eyrie.config import ZMQChannel
+from cs.eyrie.config import ZMQChannel, setup_logging
 from cs.eyrie.zk_consumer import ZKConsumer
 
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ test_requirements = [
 
 setup(
     name='cs.eyrie',
-    version='0.3.0',
+    version='0.4.0',
     description='Primitives for building ZMQ pipelines.',
     long_description=readme + '\n\n' + history,
     author='CrowdStrike, Inc.',


### PR DESCRIPTION
Support sampling of a Kafka topic by switching to PUB/SUB, so that the kafka consumer will consume as fast as possible, dropping messages if workers consuming from `kafka_router` cannot keep up.