### PR TITLE
Simplify rebalance

### DIFF
--- a/cs/eyrie/scripts/kafka_consumer.py
+++ b/cs/eyrie/scripts/kafka_consumer.py
@@ -189,7 +189,8 @@ class Ranger(object):
         if self.consumer is not None:
             self.logger.info('Stopping Kafka consumer')
             self.consumer.stop()
-        super(Ranger, self).terminate()
+        self.logger.info('Closing ZMQ channel')
+        self.channel.close()
 
 
 def main():

--- a/cs/eyrie/scripts/kafka_consumer.py
+++ b/cs/eyrie/scripts/kafka_consumer.py
@@ -11,6 +11,7 @@ import time
 
 import gevent
 
+from kafka.common import FailedPayloadsError
 from kafka.common import KafkaMessage
 
 from kazoo.handlers.gevent import SequentialGeventHandler
@@ -132,6 +133,8 @@ class Ranger(object):
                                                             block=False):
                 self.msg_count += 1
                 self.send(*partition_msg)
+        except FailedPayloadsError:
+            self.terminate()
         except Exception:
             self.logger.exception('Error encountered, restarting consumer')
             self.consumer.stop()

--- a/cs/eyrie/zk_consumer.py
+++ b/cs/eyrie/zk_consumer.py
@@ -344,17 +344,7 @@ class ZKPartitioner(object):
         """Register ourself to listen for session events, we shut down
         if we become lost"""
         with self._state_change:
-            # Handle network partition: If connection gets suspended,
-            # change state to ALLOCATING if we had already ACQUIRED. This way
-            # the caller does not process the members since we could eventually
-            # lose session get repartitioned. If we got connected after a suspension
-            # it means we've not lost the session and still have our members. Hence,
-            # restore to ACQUIRED
-            if state == KazooState.SUSPENDED:
-                if self.state == PartitionState.ACQUIRED:
-                    self._was_allocated = True
-                    self.state = PartitionState.ALLOCATING
-            elif state == KazooState.CONNECTED:
+            if state == KazooState.CONNECTED:
                 if self._was_allocated:
                     self._was_allocated = False
                     self.state = PartitionState.ACQUIRED

--- a/cs/eyrie/zk_consumer.py
+++ b/cs/eyrie/zk_consumer.py
@@ -151,7 +151,6 @@ class ZKPartitioner(object):
 
         self.join_group()
 
-        self._was_allocated = False
         self._state_change = client.handler.rlock_object()
         client.add_listener(self._establish_sessionwatch)
 
@@ -343,12 +342,6 @@ class ZKPartitioner(object):
     def _establish_sessionwatch(self, state):
         """Register ourself to listen for session events, we shut down
         if we become lost"""
-        with self._state_change:
-            if state == KazooState.CONNECTED:
-                if self._was_allocated:
-                    self._was_allocated = False
-                    self.state = PartitionState.ACQUIRED
-
         if state == KazooState.LOST:
             self._client.handler.spawn(self._fail_out)
             return True

--- a/cs/eyrie/zk_consumer.py
+++ b/cs/eyrie/zk_consumer.py
@@ -523,10 +523,10 @@ class ZKConsumer(object):
                         self.logger.info('Restarting ZK partitioner')
                         self.zk.handler.spawn(self.init_zkp)
                     else:
-                        self.logger.info('ZK partitioner releasing set')
-                        self.zkp.release_set()
-                        self.logger.info('Re-joining group')
-                        self.zk.handler.spawn(self.zkp.join_group)
+                        self.logger.info('Scheduling ZK partitioner set release')
+                        rel_greenlet = handler.spawn(self.zkp.release_set)
+                        self.logger.info('Scheduling group re-join')
+                        rel_greenlet.link_value(lambda: self.zkp.join_group)
                 if not self.nodes:
                     self.logger.info('Partitioner aquired; setting child watch')
                     result = self.zk.get_children_async(self.zkp._group_path)


### PR DESCRIPTION
This PR refactors the ZooKeeper based consumer to bail early on any connectivity blips. This relies on an external process manager (a la Circus, Supervisor or Upstart) to restart.